### PR TITLE
Minor Code clean-up for unused variables.

### DIFF
--- a/engine/source/network/serverQuery.cc
+++ b/engine/source/network/serverQuery.cc
@@ -1462,9 +1462,7 @@ static void handleExtendedMasterServerListResponse(BitStream* stream, U32 key, U
 {
    U16 packetIndex, packetTotal;
    U32 i;
-   U16 serverCount, port;
-   U8 netNum[16];
-   char addressBuffer[256];
+   U16 serverCount;
    NetAddress addr;
 
    stream->read(&packetIndex);


### PR DESCRIPTION
Remove unused variables in handleExtendedMasterServerListResponse.