### PR TITLE
GuiProfile-Editor Groundwork

### DIFF
--- a/engine/source/gui/guiTypes.cc
+++ b/engine/source/gui/guiTypes.cc
@@ -517,7 +517,7 @@ GuiBorderProfile * GuiControlProfile::getTopProfile()
    // Attempt to find the profile specified
    if (mTopProfileName)
    {
-      GuiBorderProfile *profile = dynamic_cast<GuiBorderProfile*> (Sim::findObject(mLeftProfileName));
+      GuiBorderProfile *profile = dynamic_cast<GuiBorderProfile*> (Sim::findObject(mTopProfileName));
 
       if (profile)
       {
@@ -557,7 +557,7 @@ GuiBorderProfile * GuiControlProfile::getBottomProfile()
    // Attempt to find the profile specified
    if (mBottomProfileName)
    {
-      GuiBorderProfile *profile = dynamic_cast<GuiBorderProfile*> (Sim::findObject(mLeftProfileName));
+      GuiBorderProfile *profile = dynamic_cast<GuiBorderProfile*> (Sim::findObject(mBottomProfileName));
 
       if (profile)
       {

--- a/engine/source/gui/guiTypes.cc
+++ b/engine/source/gui/guiTypes.cc
@@ -185,7 +185,8 @@ S32 GuiBorderProfile::getPadding(const GuiControlState state)
 	return getMax(mPadding[getStateIndex(state)], 0);
 }
 
-ConsoleType(GuiProfile, TypeGuiBorderProfile, sizeof(GuiBorderProfile*), "")
+// Setup the type, this will keep Border profiles from being listed with normal profiles.
+ConsoleType(GuiBProfile, TypeGuiBorderProfile, sizeof(GuiBorderProfile*), "")
 
 ConsoleSetType(TypeGuiBorderProfile)
 {
@@ -202,6 +203,8 @@ ConsoleSetType(TypeGuiBorderProfile)
    GuiBorderProfile **obj = (GuiBorderProfile **)dptr;
    if ((*obj) == profile)
       return;
+
+   *obj = profile;
 }
 
 ConsoleGetType(TypeGuiBorderProfile)
@@ -299,6 +302,7 @@ GuiControlProfile::GuiControlProfile(void) :
 	mVAlignment    = MiddleVAlign;
 	mReturnTab     = false;
 	mNumbersOnly   = false;
+   mProfileForChildrenName = NULL;
 	mProfileForChildren = NULL;
 
 	//fill color
@@ -341,7 +345,7 @@ GuiControlProfile::GuiControlProfile(void) :
       mReturnTab = def->mReturnTab;
       mNumbersOnly = def->mNumbersOnly;
       mCursorColor = def->mCursorColor;
-      mProfileForChildren = def->mProfileForChildren;
+      mProfileForChildrenName = def->mProfileForChildrenName;
       setChildrenProfile(def->mProfileForChildren);
    }
 }
@@ -365,11 +369,11 @@ void GuiControlProfile::initPersistFields()
    addField("fillColorSL",   TypeColorI,     Offset(mFillColorSL, GuiControlProfile));
    addField("fillColorNA",   TypeColorI,     Offset(mFillColorNA, GuiControlProfile));
 
-   addField("borderDefault", TypeSimObjectPtr, Offset(mBorderDefault, GuiControlProfile));
-   addField("borderLeft",    TypeSimObjectPtr, Offset(mBorderLeft, GuiControlProfile));
-   addField("borderRight",   TypeSimObjectPtr, Offset(mBorderRight, GuiControlProfile));
-   addField("borderTop",     TypeSimObjectPtr, Offset(mBorderTop, GuiControlProfile));
-   addField("borderBottom",  TypeSimObjectPtr, Offset(mBorderBottom, GuiControlProfile));
+   addField("borderDefault", TypeGuiBorderProfile, Offset(mBorderDefault, GuiControlProfile));
+   addField("borderLeft",    TypeGuiBorderProfile, Offset(mBorderLeft, GuiControlProfile));
+   addField("borderRight",   TypeGuiBorderProfile, Offset(mBorderRight, GuiControlProfile));
+   addField("borderTop",     TypeGuiBorderProfile, Offset(mBorderTop, GuiControlProfile));
+   addField("borderBottom",  TypeGuiBorderProfile, Offset(mBorderBottom, GuiControlProfile));
 
    addField("fontType",      TypeString,     Offset(mFontType, GuiControlProfile));
    addField("fontSize",      TypeS32,        Offset(mFontSize, GuiControlProfile));
@@ -378,7 +382,7 @@ void GuiControlProfile::initPersistFields()
    addField("fontColor",     TypeColorI,     Offset(mFontColors[BaseColor], GuiControlProfile));
    addField("fontColorHL",   TypeColorI,     Offset(mFontColors[ColorHL], GuiControlProfile));
    addField("fontColorNA",   TypeColorI,     Offset(mFontColors[ColorNA], GuiControlProfile));
-   addField("fontColorSL",  TypeColorI,     Offset(mFontColors[ColorSL], GuiControlProfile));
+   addField("fontColorSL",   TypeColorI,     Offset(mFontColors[ColorSL], GuiControlProfile));
    addField("fontColorLink", TypeColorI,     Offset(mFontColors[ColorUser0], GuiControlProfile));
    addField("fontColorLinkHL", TypeColorI,     Offset(mFontColors[ColorUser1], GuiControlProfile));
 
@@ -394,7 +398,7 @@ void GuiControlProfile::initPersistFields()
 
    addField("soundButtonDown", TypeAudioAssetPtr,  Offset(mSoundButtonDown, GuiControlProfile));
    addField("soundButtonOver", TypeAudioAssetPtr,  Offset(mSoundButtonOver, GuiControlProfile));
-   addField("profileForChildren", TypeSimObjectPtr,  Offset(mProfileForChildren, GuiControlProfile));
+   addField("profileForChildren", TypeString,      Offset(mProfileForChildrenName, GuiControlProfile));
 
    addField("category", TypeString, Offset(mCategory, GuiControlProfile));
 }
@@ -418,9 +422,9 @@ GuiControlProfile* GuiControlProfile::getChildrenProfile()
       return mProfileForChildren;
 
    // Attempt to find the profile specified
-   if (mProfileForChildren)
+   if (mProfileForChildrenName)
    {
-      GuiControlProfile *profile = dynamic_cast<GuiControlProfile*> (Sim::findObject(mProfileForChildren->getName()));
+      GuiControlProfile *profile = dynamic_cast<GuiControlProfile*> (Sim::findObject(mProfileForChildrenName));
 
       if (profile)
          setChildrenProfile(profile);

--- a/engine/source/gui/guiTypes.cc
+++ b/engine/source/gui/guiTypes.cc
@@ -477,7 +477,7 @@ GuiBorderProfile * GuiControlProfile::getRightProfile()
    // Attempt to find the profile specified
    if (mRightProfileName)
    {
-      GuiBorderProfile *profile = dynamic_cast<GuiBorderProfile*> (Sim::findObject(mLeftProfileName));
+      GuiBorderProfile *profile = dynamic_cast<GuiBorderProfile*> (Sim::findObject(mRightProfileName));
 
       if (profile)
       {
@@ -486,7 +486,7 @@ GuiBorderProfile * GuiControlProfile::getRightProfile()
    }
    else
    {
-      setLeftProfile(mBorderDefault);
+      setRightProfile(mBorderDefault);
    }
 
    return mBorderRight;
@@ -733,11 +733,12 @@ void GuiControlProfile::decRefCount()
 {
    // Not sure why this was being tripped when
    // switching profiles in guieditor, but...
+   // following the way this works, it seems that a profile
+   // is being removed before it is added =/
 
-   //AssertFatal(mRefCount, "GuiControlProfile::decRefCount: zero ref count");
+   AssertFatal(mRefCount, "GuiControlProfile::%s::decRefCount: zero ref count", this->getName());
    if(!mRefCount)
 	  return;
-
    --mRefCount;
 
 	if(!mRefCount)

--- a/engine/source/gui/guiTypes.cc
+++ b/engine/source/gui/guiTypes.cc
@@ -280,9 +280,14 @@ GuiControlProfile::GuiControlProfile(void) :
 	mUseInput      = true;
 
 	mBorderDefault = NULL;
+
+   mLeftProfileName = NULL;
 	mBorderLeft = NULL;
+   mRightProfileName = NULL;
 	mBorderRight = NULL;
+   mTopProfileName = NULL;
 	mBorderTop = NULL;
+   mBottomProfileName = NULL;
 	mBorderBottom = NULL;
 	
 	// default font
@@ -323,10 +328,10 @@ GuiControlProfile::GuiControlProfile(void) :
       mFillColorNA = def->mFillColorNA;
 
       mBorderDefault = def->mBorderDefault;
-      mBorderLeft = def->mBorderDefault;
-      mBorderRight = def->mBorderDefault;
-      mBorderTop = def->mBorderDefault;
-      mBorderBottom = def->mBorderDefault;
+      mLeftProfileName = def->mLeftProfileName;
+      mRightProfileName = def->mRightProfileName;
+      mTopProfileName = def->mTopProfileName;
+      mBottomProfileName = def->mBottomProfileName;
 
       // default font
       mFontType = def->mFontType;
@@ -345,6 +350,8 @@ GuiControlProfile::GuiControlProfile(void) :
       mReturnTab = def->mReturnTab;
       mNumbersOnly = def->mNumbersOnly;
       mCursorColor = def->mCursorColor;
+
+      // Child profile
       mProfileForChildrenName = def->mProfileForChildrenName;
       setChildrenProfile(def->mProfileForChildren);
    }
@@ -358,11 +365,12 @@ GuiControlProfile::~GuiControlProfile()
 void GuiControlProfile::initPersistFields()
 {
    Parent::initPersistFields();
-
-   addField("tab",           TypeBool,       Offset(mTabable, GuiControlProfile));
-   addField("canKeyFocus",   TypeBool,       Offset(mCanKeyFocus, GuiControlProfile));
-   addField("useInput",      TypeBool,       Offset(mUseInput, GuiControlProfile));
-   addField("mouseOverSelected", TypeBool,   Offset(mMouseOverSelected, GuiControlProfile));
+   addGroup("Behavior");
+      addField("tab",           TypeBool,       Offset(mTabable, GuiControlProfile));
+      addField("canKeyFocus",   TypeBool,       Offset(mCanKeyFocus, GuiControlProfile));
+      addField("useInput",      TypeBool,       Offset(mUseInput, GuiControlProfile));
+      addField("mouseOverSelected", TypeBool,   Offset(mMouseOverSelected, GuiControlProfile));
+   endGroup("Behavior");
 
    addField("fillColor",     TypeColorI,     Offset(mFillColor, GuiControlProfile));
    addField("fillColorHL",   TypeColorI,     Offset(mFillColorHL, GuiControlProfile));
@@ -370,10 +378,10 @@ void GuiControlProfile::initPersistFields()
    addField("fillColorNA",   TypeColorI,     Offset(mFillColorNA, GuiControlProfile));
 
    addField("borderDefault", TypeGuiBorderProfile, Offset(mBorderDefault, GuiControlProfile));
-   addField("borderLeft",    TypeGuiBorderProfile, Offset(mBorderLeft, GuiControlProfile));
-   addField("borderRight",   TypeGuiBorderProfile, Offset(mBorderRight, GuiControlProfile));
-   addField("borderTop",     TypeGuiBorderProfile, Offset(mBorderTop, GuiControlProfile));
-   addField("borderBottom",  TypeGuiBorderProfile, Offset(mBorderBottom, GuiControlProfile));
+   addField("borderLeft",    TypeString, Offset(mLeftProfileName, GuiControlProfile));
+   addField("borderRight",   TypeString, Offset(mRightProfileName, GuiControlProfile));
+   addField("borderTop",     TypeString, Offset(mTopProfileName, GuiControlProfile));
+   addField("borderBottom",  TypeString, Offset(mBottomProfileName, GuiControlProfile));
 
    addField("fontType",      TypeString,     Offset(mFontType, GuiControlProfile));
    addField("fontSize",      TypeS32,        Offset(mFontSize, GuiControlProfile));
@@ -410,9 +418,174 @@ bool GuiControlProfile::onAdd()
 
    Sim::getGuiDataGroup()->addObject(this);
 
+   getLeftProfile();
+   getRightProfile();
+   getTopProfile();
+   getBottomProfile();
+
    getChildrenProfile();
 
    return true;
+}
+
+GuiBorderProfile * GuiControlProfile::getLeftProfile()
+{
+   // We can early out if we still have a valid profile
+   if (mBorderLeft)
+      return mBorderLeft;
+
+   // Attempt to find the profile specified
+   if (mLeftProfileName)
+   {
+      GuiBorderProfile *profile = dynamic_cast<GuiBorderProfile*> (Sim::findObject(mLeftProfileName));
+
+      if (profile)
+      {
+         setLeftProfile(profile);
+      }
+   }
+   else
+   {
+      setLeftProfile(mBorderDefault);
+   }
+
+   return mBorderLeft;
+}
+
+void GuiControlProfile::setLeftProfile(GuiBorderProfile * prof)
+{
+   if (prof == mBorderLeft)
+      return;
+
+   // Clear the delete notification we previously set up
+   if (mBorderLeft)
+      clearNotify(mBorderLeft);
+
+   mBorderLeft = prof;
+
+   // Make sure that the new profile will notify us when it is deleted
+   if (mBorderLeft)
+      deleteNotify(mBorderLeft);
+}
+
+GuiBorderProfile * GuiControlProfile::getRightProfile()
+{
+   // We can early out if we still have a valid profile
+   if (mBorderRight)
+      return mBorderRight;
+
+   // Attempt to find the profile specified
+   if (mRightProfileName)
+   {
+      GuiBorderProfile *profile = dynamic_cast<GuiBorderProfile*> (Sim::findObject(mLeftProfileName));
+
+      if (profile)
+      {
+         setRightProfile(profile);
+      }
+   }
+   else
+   {
+      setLeftProfile(mBorderDefault);
+   }
+
+   return mBorderRight;
+}
+
+void GuiControlProfile::setRightProfile(GuiBorderProfile * prof)
+{
+   if (prof == mBorderRight)
+      return;
+
+   // Clear the delete notification we previously set up
+   if (mBorderRight)
+      clearNotify(mBorderRight);
+
+   mBorderRight = prof;
+
+   // Make sure that the new profile will notify us when it is deleted
+   if (mBorderRight)
+      deleteNotify(mBorderRight);
+}
+
+GuiBorderProfile * GuiControlProfile::getTopProfile()
+{
+   // We can early out if we still have a valid profile
+   if (mBorderTop)
+      return mBorderTop;
+
+   // Attempt to find the profile specified
+   if (mTopProfileName)
+   {
+      GuiBorderProfile *profile = dynamic_cast<GuiBorderProfile*> (Sim::findObject(mLeftProfileName));
+
+      if (profile)
+      {
+         setTopProfile(profile);
+      }
+   }
+   else
+   {
+      setTopProfile(mBorderDefault);
+   }
+
+   return mBorderTop;
+}
+
+void GuiControlProfile::setTopProfile(GuiBorderProfile * prof)
+{
+   if (prof == mBorderTop)
+      return;
+
+   // Clear the delete notification we previously set up
+   if (mBorderTop)
+      clearNotify(mBorderTop);
+
+   mBorderTop = prof;
+
+   // Make sure that the new profile will notify us when it is deleted
+   if (mBorderTop)
+      deleteNotify(mBorderTop);
+}
+
+GuiBorderProfile * GuiControlProfile::getBottomProfile()
+{
+   // We can early out if we still have a valid profile
+   if (mBorderBottom)
+      return mBorderBottom;
+
+   // Attempt to find the profile specified
+   if (mBottomProfileName)
+   {
+      GuiBorderProfile *profile = dynamic_cast<GuiBorderProfile*> (Sim::findObject(mLeftProfileName));
+
+      if (profile)
+      {
+         setBottomProfile(profile);
+      }
+   }
+   else
+   {
+      setBottomProfile(mBorderDefault);
+   }
+
+   return mBorderBottom;
+}
+
+void GuiControlProfile::setBottomProfile(GuiBorderProfile * prof)
+{
+   if (prof == mBorderBottom)
+      return;
+
+   // Clear the delete notification we previously set up
+   if (mBorderBottom)
+      clearNotify(mBorderBottom);
+
+   mBorderBottom = prof;
+
+   // Make sure that the new profile will notify us when it is deleted
+   if (mBorderBottom)
+      deleteNotify(mBorderBottom);
 }
 
 GuiControlProfile* GuiControlProfile::getChildrenProfile()

--- a/engine/source/gui/guiTypes.h
+++ b/engine/source/gui/guiTypes.h
@@ -174,11 +174,11 @@ public:
    ColorI mFillColorSL;	//Color used when the control is selected.
    ColorI mFillColorNA; //Used if the object is not active or disabled.
 
-   GuiBorderProfile *mBorderDefault;					//The default border settings.
-   GuiBorderProfile *mBorderTop;
-   GuiBorderProfile *mBorderBottom;
-   GuiBorderProfile *mBorderLeft;
-   GuiBorderProfile *mBorderRight;
+   GuiBorderProfile* mBorderDefault;					//The default border settings.
+   GuiBorderProfile* mBorderTop;
+   GuiBorderProfile* mBorderBottom;
+   GuiBorderProfile* mBorderLeft;
+   GuiBorderProfile* mBorderRight;
 
    // font members
    StringTableEntry  mFontType;                    ///< Font face name for the control
@@ -246,7 +246,7 @@ public:
    // sound members
    AssetPtr<AudioAsset> mSoundButtonDown;                 ///< Sound played when the object is "down" ie a button is pushed
    AssetPtr<AudioAsset> mSoundButtonOver;                 ///< Sound played when the mouse is over the object
-
+   StringTableEntry mProfileForChildrenName;
    GuiControlProfile* mProfileForChildren;         ///< Profile used with children controls (such as the scroll bar on a popup menu) when defined.
 public:
    DECLARE_CONOBJECT(GuiControlProfile);

--- a/engine/source/gui/guiTypes.h
+++ b/engine/source/gui/guiTypes.h
@@ -175,9 +175,17 @@ public:
    ColorI mFillColorNA; //Used if the object is not active or disabled.
 
    GuiBorderProfile* mBorderDefault;					//The default border settings.
+   // top profile
+   StringTableEntry mTopProfileName;
    GuiBorderProfile* mBorderTop;
+   // Bottom profile
+   StringTableEntry mBottomProfileName;
    GuiBorderProfile* mBorderBottom;
+   // Left profile
+   StringTableEntry mLeftProfileName;
    GuiBorderProfile* mBorderLeft;
+   // Left profile
+   StringTableEntry mRightProfileName;
    GuiBorderProfile* mBorderRight;
 
    // font members
@@ -255,8 +263,21 @@ public:
    static void initPersistFields();
    bool onAdd();
 
-   GuiControlProfile * getChildrenProfile();
 
+   GuiBorderProfile* getLeftProfile();
+   void setLeftProfile(GuiBorderProfile* prof);
+
+   GuiBorderProfile* getRightProfile();
+   void setRightProfile(GuiBorderProfile* prof);
+
+   GuiBorderProfile* getTopProfile();
+   void setTopProfile(GuiBorderProfile* prof);
+
+   GuiBorderProfile* getBottomProfile();
+   void setBottomProfile(GuiBorderProfile* prof);
+
+   // Get and Set child profile
+   GuiControlProfile * getChildrenProfile();
    void setChildrenProfile(GuiControlProfile * prof);
 
    /// This method creates an array of bitmaps from one single bitmap with
@@ -272,10 +293,10 @@ public:
    const ColorI& getFillColor(const GuiControlState state); //Returns the fill color based on the state.
    const ColorI& getFontColor(const GuiControlState state); //Returns the font color based on the state.
 
-   GuiBorderProfile* getLeftBorder() { return ((mBorderLeft) ? mBorderLeft : mBorderDefault); };
-   GuiBorderProfile* getRightBorder() { return ((mBorderRight) ? mBorderRight : mBorderDefault); };
-   GuiBorderProfile* getTopBorder() { return ((mBorderTop) ? mBorderTop : mBorderDefault); };
-   GuiBorderProfile* getBottomBorder() { return ((mBorderBottom) ? mBorderBottom : mBorderDefault); };
+   GuiBorderProfile* getLeftBorder() { return mBorderLeft; }
+   GuiBorderProfile* getRightBorder() { return mBorderRight; }
+   GuiBorderProfile* getTopBorder() { return mBorderTop; }
+   GuiBorderProfile* getBottomBorder() { return mBorderBottom; }
 };
 DefineConsoleType( TypeGuiProfile)
 


### PR DESCRIPTION
-in ordinary GuiEditor Border profiles should no longer appear in profile list
-Separate out the border profile and control profile classes
-set the fields to take border profiles and not simobjptr
-profile children set to a string for simobject::findObject instead of simobjptr