### PR TITLE
Add VS2017, macOS, iOS builds

### DIFF
--- a/.github/workflows/PR-builds.yml
+++ b/.github/workflows/PR-builds.yml
@@ -1,8 +1,8 @@
 name: Build Packages
 on: [push, pull_request]
 jobs:
-  Build-Windows-32bit:
-    name: Build package for 32-bit x86 Windows
+  Build-Windows-32bit-VS2019:
+    name: 32-bit Windows On VS2019
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -11,13 +11,13 @@ jobs:
       - run: msbuild -m "engine/compilers/VisualStudio 2019/Torque 2D.sln" /p:Configuration=Release /p:Platform=win32
       - uses: actions/upload-artifact@v2
         with:
-          name: Torque2D_Windows_x86_32bit
+          name: Torque2D_Windows_x86_32bit_VS2019
           path: |
             .
             ! .git/
             ! engine/
-  Build-Windows-64bit:
-    name: Build package for 64-bit x86 Windows
+  Build-Windows-64bit-VS2019:
+    name: 64-bit Windows On VS2019
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +26,37 @@ jobs:
       - run: msbuild -m "engine/compilers/VisualStudio 2019/Torque 2D.sln" /p:Configuration=Release /p:Platform=x64
       - uses: actions/upload-artifact@v2
         with:
-          name: Torque2D_Windows_x86_64bit
+          name: Torque2D_Windows_x86_64bit_VS2019
+          path: |
+            .
+            ! .git/
+            ! engine/
+  Build-Windows-32bit-VS2017:
+    name: 32-bit Windows On VS2017
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: microsoft/setup-msbuild@v1.0.3
+      - run: msbuild -m "engine/compilers/VisualStudio 2017/Torque 2D.sln" /p:Configuration=Debug /p:Platform=win32
+      - run: msbuild -m "engine/compilers/VisualStudio 2017/Torque 2D.sln" /p:Configuration=Release /p:Platform=win32
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Torque2D_Windows_x86_32bit_VS2017
+          path: |
+            .
+            ! .git/
+            ! engine/
+  Build-Windows-64bit-VS2017:
+    name: 64-bit Windows On VS2017
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: microsoft/setup-msbuild@v1.0.3
+      - run: msbuild -m "engine/compilers/VisualStudio 2017/Torque 2D.sln" /p:Configuration=Debug /p:Platform=x64
+      - run: msbuild -m "engine/compilers/VisualStudio 2017/Torque 2D.sln" /p:Configuration=Release /p:Platform=x64
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Torque2D_Windows_x86_64bit_VS2017
           path: |
             .
             ! .git/
@@ -53,6 +83,32 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: Torque2D_Linux_x86_64bit
+          path: |
+            .
+            ! .git/
+            ! engine/
+  Build-MacOS:
+    name: Build package for MacOS
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cd engine/compilers/Xcode && xcodebuild -project Torque2D.xcodeproj
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Torque2D_MacOS
+          path: |
+            .
+            ! .git/
+            ! engine/
+  Build-iOS:
+    name: Build package for iOS
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cd engine/compilers/Xcode_iOS && xcodebuild CODE_SIGNING_ALLOWED=no -project Torque2D.xcodeproj
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Torque2D_iOS
           path: |
             .
             ! .git/


### PR DESCRIPTION
I'm about to get back into a busy period at work and wanted to get the PR builds in good shape. Unfortunately, I don't have a performant enough MacOS VM to be able to run the XCode well enough to click in and delete the broken file references and add the new files, so XCode builds are still busted.

Per our conversation in Discord, I've also added VS2017 builds as well, though they appear to currently be busted. I probably won't be able to add VS2017 to a windows VM and get that rectified soon. :/

I'm fighting android at the moment, but if it works well I'll add it in a separate PR.