### PR TITLE
Fix return of reference to temporary

### DIFF
--- a/engine/source/2d/gui/guiSpriteCtrl.cc
+++ b/engine/source/2d/gui/guiSpriteCtrl.cc
@@ -321,7 +321,7 @@ F32 GuiSpriteCtrl::getAspectRatio()
 	return 1.0;
 }
 
-Point2I& GuiSpriteCtrl::applyAlignment(RectI &bounds, Point2I &size)
+Point2I GuiSpriteCtrl::applyAlignment(RectI &bounds, Point2I &size)
 {
 	Point2I offset = Point2I(0, 0);
 

--- a/engine/source/2d/gui/guiSpriteCtrl.h
+++ b/engine/source/2d/gui/guiSpriteCtrl.h
@@ -77,7 +77,7 @@ public:
 	Point2I constrainLockX(Point2I &point);
 	Point2I constrainLockY(Point2I &point);
 	F32 getAspectRatio();
-	Point2I& applyAlignment(RectI &bounds, Point2I &size);
+	Point2I applyAlignment(RectI &bounds, Point2I &size);
 
 	//Animation Functions
 	void moveTo(S32 x, S32 y, S32 time, EasingFunction ease = Linear);


### PR DESCRIPTION
A reference to an object on the stack was returned in `GuiSpriteCtrl::applyAlignment` leading to segfaults in the demo application:
* starting the demo
* "Open Console"
* "Asset Manager"
* Clicking any entry in the right menu --> segfault