### PR TITLE
Fixes issue 44 - allows Linux build with compiler flag -std=c++17

### DIFF
--- a/engine/source/2d/assets/ParticleAssetFieldCollection.h
+++ b/engine/source/2d/assets/ParticleAssetFieldCollection.h
@@ -27,7 +27,7 @@
 #include "2d/assets/ParticleAssetField.h"
 #endif
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/2d/core/BatchRender.h
+++ b/engine/source/2d/core/BatchRender.h
@@ -39,7 +39,7 @@
 #include "graphics/TextureManager.h"
 #endif
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/2d/scene/Scene.h
+++ b/engine/source/2d/scene/Scene.h
@@ -51,7 +51,7 @@
 #include "2d/scene/DebugDraw.h"
 #endif
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/2d/sceneobject/Trigger.h
+++ b/engine/source/2d/sceneobject/Trigger.h
@@ -27,7 +27,7 @@
 #include "2d/sceneobject/SceneObject.h"
 #endif
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/assets/assetTagsManifest.h
+++ b/engine/source/assets/assetTagsManifest.h
@@ -27,7 +27,7 @@
 #include "sim/simBase.h"
 #endif
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/collection/hashTable.h
+++ b/engine/source/collection/hashTable.h
@@ -20,8 +20,8 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#ifndef _HASHTABLE_H
-#define _HASHTABLE_H
+#ifndef _HASHTABLE_H_
+#define _HASHTABLE_H_
 
 #include "vector.h"
 #include "platform/platform.h"
@@ -697,4 +697,4 @@ inline Value& HashMap<Key,Value,Sequence>::operator[](const Key& key)
 
 
 
-#endif// _HASHTABLE_H
+#endif// _HASHTABLE_H_

--- a/engine/source/collection/nameTags.h
+++ b/engine/source/collection/nameTags.h
@@ -27,7 +27,7 @@
 #include "sim/simBase.h"
 #endif
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/component/behaviors/behaviorInstance.h
+++ b/engine/source/component/behaviors/behaviorInstance.h
@@ -26,7 +26,7 @@
 #include "sim/simBase.h"
 #endif
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/console/console.cc
+++ b/engine/source/console/console.cc
@@ -42,7 +42,7 @@
 #include "output_ScriptBinding.h"
 #include "expando_ScriptBinding.h"
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/graphics/gColor.cc
+++ b/engine/source/graphics/gColor.cc
@@ -30,7 +30,7 @@
 #include "string/stringUnit.h"
 #endif
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/gui/guiTypes.h
+++ b/engine/source/gui/guiTypes.h
@@ -61,7 +61,7 @@
 
 #include "graphics/gFont.h"
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/module/moduleManager.h
+++ b/engine/source/module/moduleManager.h
@@ -31,7 +31,7 @@
 #include "collection/vector.h"
 #endif
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/persistence/taml/binary/tamlBinaryReader.h
+++ b/engine/source/persistence/taml/binary/tamlBinaryReader.h
@@ -23,7 +23,7 @@
 #ifndef _TAML_BINARYREADER_H_
 #define _TAML_BINARYREADER_H_
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/persistence/taml/json/tamlJSONReader.h
+++ b/engine/source/persistence/taml/json/tamlJSONReader.h
@@ -23,7 +23,7 @@
 #ifndef _TAML_JSONREADER_H_
 #define _TAML_JSONREADER_H_
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/persistence/taml/taml.h
+++ b/engine/source/persistence/taml/taml.h
@@ -47,7 +47,7 @@
 #include "sim/simBase.h"
 #endif
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 

--- a/engine/source/persistence/taml/xml/tamlXmlReader.h
+++ b/engine/source/persistence/taml/xml/tamlXmlReader.h
@@ -23,7 +23,7 @@
 #ifndef _TAML_XMLREADER_H_
 #define _TAML_XMLREADER_H_
 
-#ifndef _HASHTABLE_H
+#ifndef _HASHTABLE_H_
 #include "collection/hashTable.h"
 #endif
 


### PR DESCRIPTION
From my comment under issue 44 :

This issue is due to the header guard _HASHTABLE_H defined in hashTable.h.

That header guard is a reserved identifier in the gcc standard library ([code here in gcc repository - line 31](https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/bits/hashtable.h)).

Renaming the header guard in hashTable.h allows a full build with -std=c++17.

For the revised name I added a trailing underscore  i.e. _HASHTABLE_H_ which also brings this header guard into line with the Torque code style guidelines.

Full build tested :
OS=Debian 11
Compiler = GCC 10.2
Full builds tested with CLion and QTCreator
To note - I used a CMakeLists build in the IDEs as I do not use docker.