### PR TITLE
Fix for Linux Make build process failing with undefined references

### DIFF
--- a/engine/compilers/Make-32bit/Torque2D.mk
+++ b/engine/compilers/Make-32bit/Torque2D.mk
@@ -2,7 +2,8 @@ APPNAME := ../../../Torque2D
 
 2D_SOURCES :=            $(shell find ../../source/2d/ -name "*.cc") + \
 						 $(shell find ../../source/2d/ -name "*.cpp")
-ALGORITHM_SOURCES :=     $(shell find ../../source/algorithm/ -name "*.cc")
+ALGORITHM_SOURCES :=     $(shell find ../../source/algorithm/ -name "*.cc") + \
+                         $(shell find ../../source/algorithm/ -name "*.c")
 ASSETS_SOURCES :=        $(shell find ../../source/assets/ -name "*.cc")
 AUDIO_SOURCES :=         $(shell find ../../source/audio/ -name "*.cc")
 BITMAPFONT_SOURCES :=    $(shell find ../../source/bitmapFont/ -name "*.cc")

--- a/engine/compilers/Make-64bit/Torque2D.mk
+++ b/engine/compilers/Make-64bit/Torque2D.mk
@@ -2,7 +2,8 @@ APPNAME := ../../../Torque2D
 
 2D_SOURCES :=            $(shell find ../../source/2d/ -name "*.cc") + \
 						 $(shell find ../../source/2d/ -name "*.cpp")
-ALGORITHM_SOURCES :=     $(shell find ../../source/algorithm/ -name "*.cc")
+ALGORITHM_SOURCES :=     $(shell find ../../source/algorithm/ -name "*.cc") + \
+                         $(shell find ../../source/algorithm/ -name "*.c")
 ASSETS_SOURCES :=        $(shell find ../../source/assets/ -name "*.cc")
 AUDIO_SOURCES :=         $(shell find ../../source/audio/ -name "*.cc")
 BITMAPFONT_SOURCES :=    $(shell find ../../source/bitmapFont/ -name "*.cc")

--- a/engine/compilers/Make-64bit/Torque2D.mk
+++ b/engine/compilers/Make-64bit/Torque2D.mk
@@ -64,7 +64,7 @@ SOURCES := $(2D_SOURCES) + \
 LDFLAGS := -g -m64
 LDLIBS := -lstdc++ -lm -ldl -lpthread -lrt -lX11 -lXft -lSDL -lopenal
 
-CFLAGS := -std=c++14 -MMD -I. -Wfatal-errors -Wunused -m64 -msse -march=x86-64 -pipe
+CFLAGS := -std=c++17 -MMD -I. -Wfatal-errors -Wunused -m64 -msse -march=x86-64 -pipe
 
 CFLAGS += -I/usr/include
 CFLAGS += -I/usr/include/freetype2


### PR DESCRIPTION
Fix for Linux make build process failing with undefined references :

`undefined reference to pcg32_srandom_r`
`undefined reference to pcg32_random_r`
`undefined reference to pcg32_boundedrand_r`

The missing functions are defined in pcg_basic.c but the makefiles were only including source/algorithm/*.cc files

64 bit build tested and executables built successfully (32 bit build NOT tested but assuming same issue applies)

OS=Debian 11 using make/docker build process

Additional commit to bump 64 bit Linux build to -std=c++17
64 bit build tested and executables bult successfully.