### PR TITLE
Add open-source documentation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- New features and functionality go here
+
+### Changed
+- Changes to existing functionality go here
+
+### Deprecated
+- Soon-to-be removed features go here
+
+### Removed
+- Removed features go here
+
+### Fixed
+- Bug fixes go here
+
+### Security
+- Security improvements and vulnerability patches go here
+
+---
+
+## [1.0.0] - YYYY-MM-DD
+
+### Added
+- Initial release of Torque2D
+
+[Unreleased]: https://github.com/TorqueGameEngines/Torque2D/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/TorqueGameEngines/Torque2D/releases/tag/v1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT EMAIL]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, during this period is allowed. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to Torque2D
+
+Thank you for your interest in contributing to Torque2D! This document provides guidelines and instructions for contributing to the project.
+
+## Code of Conduct
+
+Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md) to maintain a welcoming and inclusive environment for all contributors.
+
+## Reporting Bugs
+
+Before submitting a bug report, please check if the issue has already been reported by searching the [issue tracker](https://github.com/TorqueGameEngines/Torque2D/issues).
+
+When filing a new bug report, please include:
+
+- A clear and descriptive title
+- Steps to reproduce the issue
+- Expected behavior vs. actual behavior
+- Your development environment (OS, compiler version, etc.)
+- Any relevant logs, screenshots, or code snippets
+- If possible, a minimal test case that demonstrates the issue
+
+## Proposing Features
+
+Feature proposals are welcome! Before submitting:
+
+1. Search existing issues to ensure the feature hasn't been proposed or rejected
+2. Open a new issue with the "feature request" label
+3. Describe the feature in detail, including:
+   - The problem it solves or the use case it addresses
+   - Proposed implementation approach
+   - Any potential impact on existing functionality
+   - Examples of how the feature would be used
+
+The maintainers will review your proposal and provide feedback. Once approved, you can begin implementation.
+
+## Submitting Pull Requests
+
+### Before You Start
+
+1. Fork the repository and create a new branch from `main`
+2. Name your branch descriptively (e.g., `fix/collision-bug`, `feature/new-renderer`)
+3. Ensure your changes address a specific issue or feature
+
+### C++ Coding Standards
+
+Torque2D is written in C++. Please adhere to the following guidelines:
+
+- **Follow existing formatting styles**: Match the indentation, naming conventions, and code structure used in the surrounding code
+- **Use meaningful variable and function names**: Prefer clarity over brevity
+- **Add comments where necessary**: Explain complex logic, but let the code speak for itself when possible
+- **Keep functions focused**: Each function should do one thing well
+- **Avoid unnecessary dependencies**: Minimize external library requirements
+
+### Commit Guidelines
+
+- **Write atomic commits**: Each commit should represent a single logical change
+- **Use clear commit messages**: Follow the format:
+  ```
+  <type>: <short description>
+
+  <optional detailed description>
+  ```
+  Where type is one of: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+- **Reference issues**: Include `Fixes #123` or `Closes #456` in commit messages when applicable
+- **Squash appropriately**: If your branch has multiple small fixes, consider squashing them before submission
+
+### Pull Request Process
+
+1. Ensure your code compiles without warnings
+2. Run existing tests and add new tests for your changes
+3. Update documentation as needed
+4. Submit your pull request with:
+   - A clear title and description
+   - Reference to any related issues
+   - Description of testing performed
+5. Respond to reviewer feedback promptly
+6. Be patient—reviews may take time depending on maintainer availability
+
+## Questions?
+
+If you have questions about contributing, feel free to open an issue or join our community discussions. We're happy to help!
+
+Thank you for contributing to Torque2D!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The Torque2D team takes security vulnerabilities seriously. We appreciate your efforts to responsibly disclose your findings and will make every effort to acknowledge your contributions.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+### How to Report
+
+To report a security vulnerability, please email us at:
+
+**security@torque2d.com** (or the appropriate contact email for the project)
+
+In your report, please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact of the vulnerability
+- Any suggested fixes or mitigations (if available)
+- Your contact information for follow-up questions
+
+### What to Expect
+
+- **Acknowledgment**: We will acknowledge receipt of your report within 48 hours
+- **Investigation**: Our team will investigate the vulnerability and determine its severity
+- **Timeline**: We aim to resolve critical vulnerabilities within 30 days of confirmation
+- **Updates**: We will keep you informed of our progress throughout the process
+- **Credit**: With your permission, we will acknowledge your responsible disclosure in our security advisories
+
+### Responsible Disclosure
+
+We kindly ask that you:
+
+1. Allow us reasonable time to address the vulnerability before disclosing it publicly
+2. Make a good faith effort to avoid privacy violations, destruction of data, and interruption or degradation of our services
+3. Only interact with accounts you own or with explicit permission of the account holder
+4. Not access or modify data belonging to others without authorization
+
+### Public Disclosure
+
+Once a vulnerability has been addressed, we will publish a security advisory detailing the issue and the fix. We request that you coordinate with us on the timing of any public disclosure to ensure our users have adequate time to apply patches.
+
+Thank you for helping keep Torque2D and our users safe!


### PR DESCRIPTION
Adds four standard open-source documentation files to the repository:

- CONTRIBUTING.md: Guidelines for bug reports, feature proposals, and pull requests
- CODE_OF_CONDUCT.md: Contributor Covenant v2.1 adoption
- CHANGELOG.md: Keep a Changelog format template
- SECURITY.md: Security vulnerability reporting instructions

Closes issue #82 